### PR TITLE
swift-tools 4.2 support (Swift Packager)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ import PackageDescription
 let package = Package(
     name: "SwiftySound",
     products: [
-        .library(name: "SwiftySound", targets: ["SwiftySound"])
+        .library(name: "SwiftySound", targets: ["SwiftySound-iOS"])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -5,5 +5,8 @@ let package = Package(
     name: "SwiftySound",
     products: [
         .library(name: "SwiftySound", targets: ["SwiftySound-iOS"])
+    ],
+    targets: [
+        .target(name: "SwiftySound-iOS", dependencies: [])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,10 @@
+    
+// swift-tools-version:4.2
 import PackageDescription
 
 let package = Package(
     name: "SwiftySound"
+    products: [
+        .library(name: "SwiftySound", targets: ["SwiftySound"])
+    ],
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,3 @@
-    
 // swift-tools-version:4.2
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,6 @@ let package = Package(
         .library(name: "SwiftySound", targets: ["SwiftySound-iOS"])
     ],
     targets: [
-        .target(name: "SwiftySound-iOS", dependencies: [])
+        .target(name: "SwiftySound-iOS", dependencies: [], path: "Sources")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,8 @@
 import PackageDescription
 
 let package = Package(
-    name: "SwiftySound"
+    name: "SwiftySound",
     products: [
         .library(name: "SwiftySound", targets: ["SwiftySound"])
-    ],
+    ]
 )


### PR DESCRIPTION
Swift Package Manager now requires declaring a swift-tools version, as well as declaring a product.